### PR TITLE
Updated buffer access to match new IMemoryBufferReference function

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -45,17 +45,6 @@
 #include "winrt/Windows.Media.Audio.h"
 #include "winrt/Windows.Media.MediaProperties.h"
 
-
-//////////////////////////////////////////////////////////////////////////
-// must define this by hand
-// must come before using namespace stuff because IUnknown will be ambiguous
-MIDL_INTERFACE("5b0d3235-4dba-4d44-865e-8f1d0e4fd04d")
-
-IMemoryBufferByteAccess : IUnknown
-{
-	virtual HRESULT STDMETHODCALLTYPE GetBuffer(BYTE   **value, UINT32 *capacity);
-};
-
 //////////////////////////////////////////////////////////////////////////
 // notice the namespaces match the header file names
 using namespace winrt;
@@ -111,7 +100,7 @@ public:
 	{
 		Start();
 
-		Sleep(4000);
+		std::this_thread::sleep_for(std::chrono::milliseconds(4000));
 
 		Stop();
 	}
@@ -294,18 +283,7 @@ private:
 	float *GetDataPtrFromBuffer(AudioBuffer &buffer)
 	{
 		IMemoryBufferReference buffer_reference = buffer.CreateReference();
-
-		// this is where I'm stuck, this seems pretty good
-		com_ptr<IMemoryBufferByteAccess> byte_buffer_access;
-
-		// this cast is neat, thanks cppwinrt (not a C style cast at all)
-		// it actually queries this different interface behind the scenes
-		byte_buffer_access = buffer_reference.as<IMemoryBufferByteAccess>();
-
-		// Get the raw buffer from the AudioFrame
-		BYTE* data_byte_ptr = nullptr;
-		unsigned int byte_read = 0;
-		byte_buffer_access->GetBuffer(&data_byte_ptr, &byte_read);
+		uint8_t* data_byte_ptr = buffer_reference.data();
 
 		// Cast to float since the data we are generating is float
 		float* data_float_ptr = (float*)data_byte_ptr;

--- a/WindowsAudioGraph.vcxproj
+++ b/WindowsAudioGraph.vcxproj
@@ -22,28 +22,28 @@
     <ProjectGuid>{079790FD-97A0-428D-BF8D-83D24C1D6A56}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Console</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>WindowsAudioGraph</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
@@ -51,7 +51,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>


### PR DESCRIPTION
The Windows.Foundation.IMemoryBufferReference class now as a data() function that can be used to get the data pointer returned by the IMemoryBufferByteAccess::GetBuffer() method: https://github.com/microsoft/cppwinrt/pull/956 This commit updates the audio graph example to use this new function. This change may require the user to install the Universal Windows Platform development Workload.

(I've also updated the Sleep() function to use std::this_thread::sleep_for() instead. I'm not sure where the declaration of Sleep() should be.)